### PR TITLE
QoL Dispenser Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.civclassic.oldenchanting</groupId>
   <artifactId>OldEnchanting</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   
   <build>
     <sourceDirectory>${basedir}/src</sourceDirectory>

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -1,9 +1,11 @@
 package com.civclassic.oldenchanting;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -40,6 +42,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 
 import com.comphenix.protocol.PacketType;
@@ -310,6 +313,31 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 				Player shooter = (Player) source;
 				shooter.giveExp(xpPerBottle);
 				bottle.teleport(shooter.getEyeLocation());
+			}
+			else if (source instanceof BlockProjectileSource) {
+				List<Player> nearby = bottle.getNearbyEntities(0.9, 0.9, 0.9)
+						.stream()
+						.filter((entity) -> entity instanceof Player)
+						.map((entity) -> (Player) entity)
+						.collect(Collectors.toList());
+				if (nearby.isEmpty()) {
+					event.setShowEffect(false);
+					event.setExperience(0);
+					return;
+				}
+				Player closest = null;
+				double distance = Double.MAX_VALUE;
+				for (Player player : nearby) {
+					// Calculate how close this player is to the xp bottle
+					double tempDistance = player.getLocation().distance(bottle.getLocation());
+					// If there's no other player to compare to, just set this player as the closest
+					// or if this player is closer, then set this player as the closest
+					if (closest == null || tempDistance < distance) {
+						closest = player;
+						distance = tempDistance;
+					}
+				}
+				closest.giveExp(xpPerBottle);
 			}
 		}
 		else {

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -43,6 +43,7 @@ import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
@@ -343,6 +344,14 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 		if (held == null || !Material.EMERALD.equals(held.getType()) || held.getDurability() != 0) {
 			return;
 		}
+		// If the item is lored, it's probably a custom item, back out
+		if (held.hasItemMeta()) {
+			ItemMeta meta = held.getItemMeta();
+			if (meta != null && meta.hasLore()) {
+				return;
+			}
+		}
+		// If the amount is unsupported, back out
 		int amount = held.getAmount();
 		if (amount <= 0) {
 			return;

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -27,6 +27,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExpEvent;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.event.enchantment.PrepareItemEnchantEvent;
+import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.ExpBottleEvent;
 import org.bukkit.event.inventory.FurnaceExtractEvent;
@@ -41,6 +42,7 @@ import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -267,12 +269,29 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	}
 
 	@EventHandler
-	public void onFishingXP(PlayerFishEvent event) {
+	public void onFishingXP(EntityBreedEvent event) {
+		if (noExp) {
+			event.setExperience(0);
+		}
+		else {
+			event.setExperience((int) Math.ceil(event.getExperience() * xpMod));
+		}
+	}
+
+	@EventHandler
+	public void onBreedXP(PlayerFishEvent event) {
 		if (noExp) {
 			event.setExpToDrop(0);
 		}
 		else {
 			event.setExpToDrop((int) Math.ceil(event.getExpToDrop() * xpMod));
+		}
+	}
+
+	@EventHandler
+	public void onMerchantXP(MerchantRecipe event) {
+		if (noExp) {
+			event.setExperienceReward(false);
 		}
 	}
 	

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -313,6 +313,40 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 		}
 	}
 	
+	@EventHandler
+	public void onEmeraldXP(PlayerInteractEvent event) {
+		// If emerald crafting is not enabled, back out
+		if (!emeraldCrafting) {
+			return;
+		}
+		// If the action is not a right click, back out
+		switch (event.getAction()) {
+			case RIGHT_CLICK_AIR:
+			case RIGHT_CLICK_BLOCK:
+				break;
+			default:
+				return;
+		}
+		// If the item is not an emerald, back out
+		ItemStack held = event.getPlayer().getInventory().getItemInMainHand();
+		if (held == null || !Material.EMERALD.equals(held.getType()) || held.getDurability() != 0) {
+			return;
+		}
+		int amount = held.getAmount();
+		if (amount <= 0) {
+			return;
+		}
+		// Apply the xp to the player at the cost of an emerald
+		event.getPlayer().giveExp(xpPerBottle * 9);
+		if (amount == 1) {
+			event.getPlayer().getInventory().setItemInMainHand(null);
+		}
+		else {
+			held.setAmount(--amount);
+			event.getPlayer().getInventory().setItemInMainHand(held);
+		}
+	}
+
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void xpBottleEvent(ExpBottleEvent event) {
 		if (noExp) {

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -37,6 +37,7 @@ import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.player.PlayerExpChangeEvent;
+import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.inventory.ItemStack;
@@ -261,6 +262,16 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 					&& totalExp >= xpPerBottle) {
 				createXPBottles(player, totalExp);
 			}
+		}
+	}
+
+	@EventHandler
+	public void onFishingXP(PlayerFishEvent event) {
+		if (noExp) {
+			event.setExpToDrop(0);
+		}
+		else {
+			event.setExpToDrop((int) Math.ceil(event.getExpToDrop() * xpMod));
 		}
 	}
 	

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -15,6 +15,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.ThrownExpBottle;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -302,13 +303,16 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void xpBottleEvent(ExpBottleEvent event) {
-		if(noExp) {
-			ProjectileSource source = event.getEntity().getShooter();
-			if(source instanceof Player) {
+		if (noExp) {
+			ThrownExpBottle bottle = event.getEntity();
+			ProjectileSource source = bottle.getShooter();
+			if (source instanceof Player) {
 				Player shooter = (Player) source;
 				shooter.giveExp(xpPerBottle);
+				bottle.teleport(shooter.getEyeLocation());
 			}
-		} else {
+		}
+		else {
 			event.setExperience(xpPerBottle);
 		}
 	}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,7 @@ xpmod: 0.2 #multiply all xp drops by this
 loot_mult: 1.5 #multiply xp by this for each level of looting
 emerald_crafting: true #enables crafting xp bottles into emeralds
 block_natural_exp: true #disables xp from dropping. xp from bottles will be given to players directly
+unnatural_dispensed_xp_radius: 2 #when block_natural_exp is enabled, what should the radius of dispensed xp be?
 infinite_enchant: true #allows infinite enchanting instead of unrepairable items
 exp_per_bottle: 10 #the amount of xp each bottle should give and hold
 #give a special xp modifier to certain mobs


### PR DESCRIPTION
This change has been made [at the request of DriftL0rd](https://www.reddit.com/r/civclassics/comments/cq34as/minor_suggestion_regarding_xp_bottles/ewu238l/?context=6), he noticed that xp can only be granted via players throwing xp bottles after creating a machine to auto dispense. The response from the community was to install mods, I object to the line of thinking that gameplay should be replaced with mods, and so this change gives players more freedom. It also fixes a funny consequence of orb xp being disabled, see the individual commit messages for more information.