### PR TITLE
Major update to OldEnchanting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# Editorconfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+continuation_indent_size = 8
+
+[*.java]
+indent_style = tab
+indent_size = 4
+
+[*.xml]
+indent_style = tab
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.civclassic.oldenchanting</groupId>
     <artifactId>OldEnchanting</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
   
     <build>
         <sourceDirectory>${basedir}/src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -1,63 +1,67 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.civclassic.oldenchanting</groupId>
-  <artifactId>OldEnchanting</artifactId>
-  <version>1.0.1</version>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.civclassic.oldenchanting</groupId>
+    <artifactId>OldEnchanting</artifactId>
+    <version>1.0.1</version>
   
-  <build>
-    <sourceDirectory>${basedir}/src</sourceDirectory>
-    <resources>
-        <resource>
-            <directory>${basedir}/src/main/resources</directory>
-            <includes>
-                <include>*.yml</include>
-            </includes>
-            <filtering>true</filtering>
-        </resource>
-    </resources>
-    <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.3</version>
-            <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
-            </configuration>
-        </plugin>
-    </plugins>
-  </build>
+    <build>
+        <sourceDirectory>${basedir}/src</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <includes>
+                    <include>*.yml</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
   
-  <dependencies>
-    <dependency>
-        <groupId>org.spigotmc</groupId>
-        <artifactId>spigot</artifactId>
-        <version>1.12-R0.1-SNAPSHOT</version>
-        <scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>com.comphenix.protocol</groupId>
-        <artifactId>ProtocolLib-API</artifactId>
-        <version>4.3.0</version>
-    </dependency>
-    <dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.12-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib-API</artifactId>
+            <version>4.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>vg.civcraft.mc.civmodcore</groupId>
             <artifactId>CivModCore</artifactId>
             <version>1.6.0</version>
         </dependency>
-  </dependencies>
+    </dependencies>
+
     <repositories>
         <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
-        	<id>dmulloy</id>
-        	<url>http://repo.dmulloy2.net/nexus/repository/public/</url>
+            <id>dmulloy</id>
+            <url>http://repo.dmulloy2.net/nexus/repository/public/</url>
         </repository>
-            <repository>
-      <id>devoted-repo</id>
-      <url>https://build.devotedmc.com/plugin/repository/everything/</url>
-    </repository>
+        <repository>
+            <id>devoted-repo</id>
+            <url>https://build.devotedmc.com/plugin/repository/everything/</url>
+        </repository>
     </repositories>
+
 </project>

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -45,6 +45,7 @@ import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantRecipe;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.Recipe;
@@ -364,10 +365,18 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	}
 
 	@EventHandler(priority=EventPriority.HIGHEST)
-	public void onMerchantExp(MerchantRecipe event) {
-		// If exp from merchants is disabled, prevent exp from being rewarded
-		if (this.disableGrindExp) {
-			event.setExperienceReward(false);
+	public void onMerchantRecipe(InventoryOpenEvent event) {
+		// If not disabling merchant recipe xp, back out
+		if (!this.disableGrindExp) {
+			return;
+		}
+		// If not a merchant inventory, back out
+		if (!(event.getInventory() instanceof Merchant)) {
+			return;
+		}
+		// Disable all exp rewards
+		for (MerchantRecipe recipe : ((Merchant) event.getInventory()).getRecipes()) {
+			recipe.setExperienceReward(false);
 		}
 	}
 

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -203,7 +203,7 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 		this.expPerBottle = config.getInt("exp_per_bottle", 10);
 		if (this.expPerBottle <= 0) {
 			Bukkit.getLogger().warning("Experience per bottle [" + this.expPerBottle + "] is unsupported, defaulting to 10");
-			this.maxRepairCost = 10;
+			this.expPerBottle = 10;
 		}
 		// Allows player's to store their levels in bottles if constantBottleEXP is enabled
 		this.allowExpRecovery = config.getBoolean("allow_exp_recovery", true);

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -401,7 +401,11 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 			if (thrower instanceof Player) {
 				Player player = (Player) thrower;
 				player.giveExp(event.getExperience());
-				player.playSound(player.getEyeLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1f, 1f);
+				// Play the experience sound as no experience orbs will be spawned
+				// Credit to Team CoFH for the random pitch generator, see their code below
+				// https://github.com/CoFH/ThermalFoundation/blob/1.12/src/main/java/cofh/thermalfoundation/item/tome/ItemTomeExperience.java#L268
+				// This is a reasonable use of their "Copy portions of this code for use in other projects." clause.
+				player.getWorld().playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 0.1F, (random.nextFloat() - random.nextFloat()) * 0.35f + 0.9f);
 				event.setExperience(0);
 				bottle.teleport(player);
 			}

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -2,17 +2,15 @@ package com.civclassic.oldenchanting;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftInventoryView;
 import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftItemStack;
 import org.bukkit.enchantments.Enchantment;
@@ -22,6 +20,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.ThrownExpBottle;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -41,15 +40,17 @@ import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.player.PlayerExpChangeEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.MerchantRecipe;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 
 import com.comphenix.protocol.PacketType;
@@ -64,30 +65,36 @@ import vg.civcraft.mc.civmodcore.itemHandling.ItemMap;
 
 public class OldEnchanting extends JavaPlugin implements Listener {
 
-	private static Random rand = new Random();
+	private static final Random random = new Random();
 
+	private static final ItemStack lapis = new ItemStack(Material.INK_SACK, 64, (short) 4);
 	private static final ItemStack emerald = new ItemStack(Material.EMERALD, 1);
-	private static final ShapelessRecipe emeraldToEXP;
+	private static final ShapelessRecipe emeraldToExp;
 	private static final ShapedRecipe expToEmerald;
-	
+
+	private PacketAdapter hideEnchantsAdapter;
+
 	private boolean hideEnchants;
 	private boolean fillLapis;
-	private boolean randomize;
-	private double xpMod;
-	private double lootMod;
+	private boolean randomiseEnchants;
+	private double experienceModifier;
+	private double lootModifier;
 	private boolean emeraldCrafting;
 	private boolean emeraldLeveling;
-	private Map<EntityType, Double> xpModifiers;
-	private boolean noExp;
-	private double dispenserXPRadius;
-	private int xpPerBottle;
-	private boolean infiniteEnchant;
+	private boolean disableGrindExp;
+	private boolean preventOrbExp;
+	private boolean directBottleExp;
+	private boolean infiniteRepair;
 	private int maxRepairCost;
-	
+	private boolean constantBottleExp;
+	private int expPerBottle;
+	private boolean allowExpRecovery;
+	private Map<EntityType, Double> entityExpDropModifiers;
+
 	static {
 		// Recipe that crafts Bottles o' Enchanting from Emeralds
-		emeraldToEXP = new ShapelessRecipe(new ItemStack(Material.EXP_BOTTLE, 9));
-		emeraldToEXP.addIngredient(Material.EMERALD);
+		emeraldToExp = new ShapelessRecipe(new ItemStack(Material.EXP_BOTTLE, 9));
+		emeraldToExp.addIngredient(Material.EMERALD);
 		// Recipe that crafts Emeralds from Bottles o' Enchanting
 		expToEmerald = new ShapedRecipe(emerald);
 		expToEmerald.shape("xxx", "xxx", "xxx");
@@ -97,279 +104,301 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	@Override
 	public void onEnable() {
 		saveDefaultConfig();
-		hideEnchants = getConfig().getBoolean("hide_enchants");
-		fillLapis = getConfig().getBoolean("fill_lapis");
-		randomize = getConfig().getBoolean("randomize_enchants");
-		xpMod = getConfig().getDouble("xpmod");
-		lootMod = getConfig().getDouble("loot_mult");
-		this.emeraldCrafting = getConfig().getBoolean("emerald_crafting", true);
-		if (this.emeraldCrafting) {
-			getServer().addRecipe(emeraldToEXP);
-			getServer().addRecipe(expToEmerald);
-		}
-		emeraldLeveling = getConfig().getBoolean("emerald_leveling", true);
-		xpModifiers = new HashMap<EntityType, Double>();
-		ConfigurationSection entities = getConfig().getConfigurationSection("entities");
-		for(String key : entities.getKeys(false)) {
-			EntityType type = EntityType.valueOf(key);
-			if(type != null) {
-				xpModifiers.put(type, entities.getDouble(key));
+		FileConfiguration config = getConfig();
+		// Hides what enchantment will be granted within the Enchanting Table GUI
+		this.hideEnchants = config.getBoolean("hide_enchants", true);
+		if (this.hideEnchants) {
+			if (this.hideEnchantsAdapter != null) {
+				ProtocolLibrary.getProtocolManager().removePacketListener(this.hideEnchantsAdapter);
 			}
-		}
-		noExp = getConfig().getBoolean("block_natural_exp", true);
-		dispenserXPRadius = getConfig().getDouble("unnatural_dispensed_xp_radius", 2d);
-		if (dispenserXPRadius < 2) {
-			getLogger().warning("Your unnatural dispenser radius (" + dispenserXPRadius + ") is smaller than two blocks and so may result is unusual behaviour.");
-		}
-		else if (dispenserXPRadius > 7) {
-			getLogger().warning("Your unnatural dispenser radius (" + dispenserXPRadius + ") is larger than the distance xp orbs will naturally gravitate towards players.");
-		}
-		xpPerBottle = getConfig().getInt("exp_per_bottle", 10);
-		infiniteEnchant = getConfig().getBoolean("infinite_enchant", true);
-		maxRepairCost = getConfig().getInt("max_repair_cost", 35);
-
-		getServer().getPluginManager().registerEvents(this, this);
-		if(hideEnchants) {
-			ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(this, PacketType.Play.Server.WINDOW_DATA) {
+			this.hideEnchantsAdapter = new PacketAdapter(this, PacketType.Play.Server.WINDOW_DATA) {
 				public void onPacketSending(PacketEvent event) {
 					PacketContainer packet = event.getPacket();
 					int property = packet.getIntegers().read(1);
 					switch(property) {
-					case 3:
-					case 4:
-					case 5:
-					case 6:
-						packet.getIntegers().write(2, -1);
+						case 3:
+						case 4:
+						case 5:
+						case 6:
+							packet.getIntegers().write(2, -1);
 					}
 				}
-			});
+			};
+			ProtocolLibrary.getProtocolManager().addPacketListener(this.hideEnchantsAdapter);
 		}
+		// Automatically fills the consumable slot with the Enchanting Table GUI with Lapis Lazuli
+		// NOTE: The Lapis Lazuli cannot be removed by the player
+		this.fillLapis = config.getBoolean("fill_lapis", true);
+		if (this.fillLapis) {
+			// Puts Lapis Lazuli in Enchanting Table GUIs if any are active which may happen during a /reload
+			for (Player player : Bukkit.getOnlinePlayers()) {
+				InventoryView inventory = player.getOpenInventory();
+				if (inventory == null) {
+					continue;
+				}
+				if (inventory.getType() != InventoryType.ENCHANTING) {
+					continue;
+				}
+				inventory.setItem(1, lapis.clone());
+			}
+		}
+		// Randomises the enchantment offers each time the item is placed in an Enchanting Table
+		this.randomiseEnchants = config.getBoolean("randomise_enchants", config.getBoolean("randomize_enchants", true));
+		// Experience modifier, all experience drops will be multiplied by this
+		// NOTE: Does not apply to player exp
+		// NOTE: Modifier must be zero or greater
+		this.experienceModifier = config.getDouble("experience_modifier", config.getDouble("xpmod", 0.2d));
+		if (this.experienceModifier < 0.0d) {
+			Bukkit.getLogger().warning("Experience modifier [" + this.experienceModifier + "] is unsupported, defaulting to 0.2");
+			this.experienceModifier = 0.2d;
+		}
+		// Loot modifier, multiply the amount of exp dropped from each level of Looting
+		// NOTE: Does not apply to player exp
+		// NOTE: Modifier must be zero or greater
+		this.lootModifier = config.getDouble("loot_modifier", config.getDouble("loot_mult", 1.5d));
+		if (this.lootModifier < 0.0d) {
+			Bukkit.getLogger().warning("Loot modifier [" + this.lootModifier + "] is unsupported, defaulting to 1.5");
+			this.lootModifier = 1.5d;
+		}
+		// Enables xp bottles to be crafted from emeralds and vice versa
+		this.emeraldCrafting = config.getBoolean("emerald_crafting", true);
+		if (this.emeraldCrafting) {
+			getServer().addRecipe(emeraldToExp);
+			getServer().addRecipe(expToEmerald);
+		}
+		// Enables gaining xp from emeralds directly without needing to craft and use xp bottles if emeraldCrafting is enabled
+		this.emeraldLeveling = config.getBoolean("emerald_leveling", true);
+		// Disables exp from mobs, fishing, mining, breeding, furnace extracting, etc
+		this.disableGrindExp = config.getBoolean("disable_grind_exp", true);
+		// Prevents exp orbs from granting xp
+		// NOTE: This will not prevent exp orbs from spawning
+		this.preventOrbExp = config.getBoolean("prevent_orb_exp", true);
+		// Ensures that the player who threw the xp bottle is the one to get the xp
+		// NOTE: experienceModifier will not apply to directly granted exp
+		this.directBottleExp = config.getBoolean("direct_bottle_exp", true);
+		// Backwards compatibility check
+		if (config.getBoolean("block_natural_exp", false)) {
+			this.disableGrindExp = true;
+			this.preventOrbExp = true;
+			this.directBottleExp = true;
+		}
+		// Allows items to be repaired infinitely, will require a level cap
+		this.infiniteRepair = config.getBoolean("infinite_repair", config.getBoolean("infinite_enchant", true));
+		// Defines the maximum repair cost of an item if infiniteRepair is enabled
+		// NOTE: Value must be two or greater
+		this.maxRepairCost = config.getInt("max_repair_cost", 33);
+		if (this.maxRepairCost < 2) {
+			Bukkit.getLogger().warning("Maximum repair cost [" + this.maxRepairCost + "] is unsupported, defaulting to 33");
+			this.maxRepairCost = 33;
+		}
+		// Ensures that xp bottles produce a set amount of exp
+		this.constantBottleExp = config.getBoolean("constant_bottle_exp", true);
+		// Defines the set amount of xp that xp bottles will produce if constantBottleEXP is enabled
+		// NOTE: Value must be a positive integer
+		this.expPerBottle = config.getInt("exp_per_bottle", 10);
+		if (this.expPerBottle <= 0) {
+			Bukkit.getLogger().warning("Experience per bottle [" + this.expPerBottle + "] is unsupported, defaulting to 10");
+			this.maxRepairCost = 10;
+		}
+		// Allows player's to store their levels in bottles if constantBottleEXP is enabled
+		this.allowExpRecovery = config.getBoolean("allow_exp_recovery", true);
+		// Modifies the exp drops for specific mob types, which will be used in lieu of experienceModifier
+		// NOTE: Players have an implicit modifier of 1.0
+		// NOTE: NOTE: Modifiers must be zero or greater
+		this.entityExpDropModifiers = new HashMap<>();
+		this.entityExpDropModifiers.put(EntityType.PLAYER, 1.0d);
+		ConfigurationSection entities = config.getConfigurationSection("entities");
+		if (entities != null) {
+			for (String key : entities.getKeys(false)) {
+				EntityType type;
+				try {
+					type = EntityType.valueOf(key);
+				}
+				catch (IllegalArgumentException error) {
+					Bukkit.getLogger().warning("EntityType [" + key + "] does not exist, skipping.");
+					continue;
+				}
+				double modifier = entities.getDouble(key, 1.0d);
+				if (modifier < 0.0d) {
+					Bukkit.getLogger().warning("Experience modifier [" + modifier + "] for [" + key + "] is unsupported, defaulting to 1.0");
+					modifier = 1.0d;
+				}
+				this.entityExpDropModifiers.put(type, modifier);
+			}
+		}
+		// Start listening to events
+		getServer().getPluginManager().registerEvents(this, this);
 	}
 
 	@Override
 	public void onDisable() {
+		// Unregisters the hide enchantments adapter
+		if (this.hideEnchants) {
+			if (this.hideEnchantsAdapter != null) {
+				ProtocolLibrary.getProtocolManager().removePacketListener(this.hideEnchantsAdapter);
+			}
+		}
+		// Remove the Lapis Lazuli from Enchanting Tables to prevent dupes
+		if (this.fillLapis) {
+			for (Player player : Bukkit.getOnlinePlayers()) {
+				InventoryView inventory = player.getOpenInventory();
+				if (inventory == null) {
+					continue;
+				}
+				if (inventory.getType() != InventoryType.ENCHANTING) {
+					continue;
+				}
+				inventory.setItem(1, null);
+			}
+		}
+		// Remove the emerald crafting recipes
 		if (this.emeraldCrafting) {
 			Iterator<Recipe> recipes = getServer().recipeIterator();
 			while (recipes.hasNext()) {
 				Recipe current = recipes.next();
-				if (current == emeraldToEXP || current == expToEmerald) {
+				if (current == emeraldToExp || current == expToEmerald) {
 					recipes.remove();
 				}
 			}
 		}
-	}
-
-
-	
-	@EventHandler
-	public void onServerCommand(ServerCommandEvent event) {
-		if(event.getCommand().equals("stop")) {
-			//Close all inventories before the server shuts down so lapis doesn't get duped
-			for(Player player : Bukkit.getOnlinePlayers()) {
-				player.closeInventory();
-			}
-		}
+		// Clear our entity experience modifiers
+		this.entityExpDropModifiers.clear();
+		// Clear the event listeners from this plugin
+		// NOTE: It's cast to Plugin because this plugin extends Plugin but also implements
+		//       Listener, so we need to make this call unambiguous. Try it for yourself.
+		HandlerList.unregisterAll((Plugin) this);
 	}
 	
 	@EventHandler(priority=EventPriority.HIGHEST)
 	public void onEntityDeath(EntityDeathEvent event) {
-		if(noExp) {
+		// If exp from mobs is disabled, prevent exp from being dropped
+		if (this.disableGrindExp) {
 			event.setDroppedExp(0);
 			return;
 		}
 		LivingEntity entity = event.getEntity();
-		if(entity.getType() == EntityType.PLAYER) return;
-		double xp = event.getDroppedExp();
-		if(xp == 0) return;
-		xp *= xpModifiers.containsKey(entity.getType()) ? xpModifiers.get(entity.getType()) : xpMod;
-		if(entity.getKiller() != null) {
+		EntityType entityType = entity.getType();
+		int experience = event.getDroppedExp();
+		// If there's an exp modifier for this mob type, apply it
+		if (this.entityExpDropModifiers.containsKey(entityType)) {
+			experience = applyModifier(experience, this.entityExpDropModifiers.get(entityType));
+		}
+		// Otherwise apply the general experience modifier
+		// DOES NOT APPLY TO XP DROPPED FROM PLAYERS!
+		else if (entityType != EntityType.PLAYER) {
+			experience = applyModifier(experience, this.experienceModifier);
+		}
+		// If the entity was killed by a player with Looting, apply modifier
+		// DOES NOT APPLY TO XP DROPPED FROM PLAYERS!
+		if (entityType != EntityType.PLAYER) {
 			Player killer = entity.getKiller();
-			if(killer.getInventory().getItemInMainHand() != null) {
-				if(killer.getInventory().getItemInMainHand().hasItemMeta() && killer.getInventory().getItemInMainHand().getItemMeta().hasEnchant(Enchantment.LOOT_BONUS_MOBS)) {
-					double mod = lootMod * killer.getInventory().getItemInMainHand().getItemMeta().getEnchantLevel(Enchantment.LOOT_BONUS_MOBS);
-					xp *= mod;
+			if (killer != null) {
+				ItemStack held = killer.getInventory().getItemInMainHand();
+				if (held != null && held.hasItemMeta()) {
+					ItemMeta meta = held.getItemMeta();
+					if (meta.hasEnchant(Enchantment.LOOT_BONUS_MOBS)) {
+						double modifier = this.lootModifier * meta.getEnchantLevel(Enchantment.LOOT_BONUS_MOBS);
+						experience = applyModifier(experience, modifier);
+					}
 				}
 			}
 		}
-		event.setDroppedExp(Math.max(1, (int)xp));
+		// Apple the modified experience
+		event.setDroppedExp(Math.max(0, experience));
 	}
-	
+
 	@EventHandler(priority=EventPriority.HIGHEST)
 	public void onBlockExp(BlockExpEvent event) {
-		event.setExpToDrop(noExp ? 0 : (int) Math.ceil(((double)event.getExpToDrop() * xpMod)));
-	}
-	
-	@EventHandler
-	public void onEnchantItem(EnchantItemEvent event) {
-		Player player = event.getEnchanter();
-		int actualCost = event.getExpLevelCost() - event.whichButton();
-		Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> {
-			player.setLevel(player.getLevel() - actualCost);
-		});
-		if(fillLapis) {
-			event.getInventory().setItem(1, new ItemStack(Material.INK_SACK, 64, (short) 4));
-		}
-	}
-	
-	@EventHandler
-	public void onPrepareItemEnchant(PrepareItemEnchantEvent event) {
-		CraftInventoryView view = (CraftInventoryView) event.getView();
-		ContainerEnchantTable table = (ContainerEnchantTable) view.getHandle();
-		if(randomize) {
-			table.f = rand.nextInt();
-		}
-	}
-	
-	@EventHandler
-	public void onInventoryClick(InventoryClickEvent event) {
-		if(event instanceof InventoryCreativeEvent) return;
-		if(fillLapis && event != null && event.getClickedInventory() != null 
-				&& event.getClickedInventory().getType() == InventoryType.ENCHANTING && event.getCurrentItem() != null
-				&& event.getCurrentItem().getType() == Material.INK_SACK && event.getCurrentItem().getDurability() == 4) {
-			event.setCancelled(true);
-		}
-	}
-	
-	@EventHandler
-	public void onInventoryOpen(InventoryOpenEvent event) {
-		if(fillLapis && event.getInventory().getType() == InventoryType.ENCHANTING) {
-			event.getInventory().setItem(1, new ItemStack(Material.INK_SACK, 64, (short) 4));
-		}
-	}
-	
-	@EventHandler
-	public void onInventoryClose(InventoryCloseEvent event) {
-		if(fillLapis && event.getInventory().getType() == InventoryType.ENCHANTING) {
-			event.getInventory().setItem(1, null);
-		}
-	}
-	
-	@EventHandler
-	public void onBlockBreak(BlockBreakEvent event) {
-		if(event.getBlock().getType() == Material.ENCHANTMENT_TABLE) {
-			for(ItemStack item : event.getBlock().getDrops()) {
-				if(item.getType() == Material.INK_SACK) {
-					event.getBlock().getDrops().remove(item);
-				}
-			}
-		}
-	}
-	
-	@EventHandler
-	public void onPrepareAnvil(PrepareAnvilEvent event) {
-		if(!infiniteEnchant) return;
-		ItemStack result = event.getResult();
-		if(result != null && result.getType() != Material.AIR) {
-			net.minecraft.server.v1_12_R1.ItemStack is = CraftItemStack.asNMSCopy(result);
-			if(is == null) return;
-			if(is.getRepairCost() > maxRepairCost -2) {
-				is.setRepairCost(maxRepairCost -2);
-				event.setResult(CraftItemStack.asBukkitCopy(is));
-			}
-		}
-	}
-	
-	@EventHandler
-	public void onFurnaceExtract(FurnaceExtractEvent event) {
-		event.setExpToDrop(noExp ? 0 : (int) Math.max(1,(double) event.getExpToDrop() * xpMod));
-	}
-	
-	@EventHandler
-	public void onPlayerInteract(PlayerInteractEvent event) {
-		Block b = event.getClickedBlock();
-		if(event.getAction() == Action.LEFT_CLICK_BLOCK && b != null && b.getType() == Material.ENCHANTMENT_TABLE) {
-			Player player = event.getPlayer();
-			
-			int totalExp = computeCurrentXP(player);
-			
-			if(player.getInventory().getItemInMainHand() != null
-					&& player.getInventory().getItemInMainHand().getType() == Material.GLASS_BOTTLE
-					&& totalExp >= xpPerBottle) {
-				createXPBottles(player, totalExp);
-			}
-		}
-	}
-
-	@EventHandler
-	public void onBreedXP(EntityBreedEvent event) {
-		if (noExp) {
-			event.setExperience(0);
-		}
-		else {
-			event.setExperience((int) Math.ceil(event.getExperience() * xpMod));
-		}
-	}
-
-	@EventHandler
-	public void onFishingXP(PlayerFishEvent event) {
-		if (noExp) {
+		// If exp from mining is disabled, prevent exp from being dropped
+		if (this.disableGrindExp) {
 			event.setExpToDrop(0);
 		}
+		// Otherwise apply general experience modifier
 		else {
-			event.setExpToDrop((int) Math.ceil(event.getExpToDrop() * xpMod));
+			event.setExpToDrop(applyModifier(event.getExpToDrop(), this.experienceModifier));
 		}
 	}
 
-	@EventHandler
-	public void onMerchantXP(MerchantRecipe event) {
-		if (noExp) {
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onFurnaceExp(FurnaceExtractEvent event) {
+		// If exp from furnaces is disabled, prevent exp from being dropped
+		if (this.disableGrindExp) {
+			event.setExpToDrop(0);
+		}
+		// Otherwise apply general experience modifier
+		else {
+			event.setExpToDrop(applyModifier(event.getExpToDrop(), this.experienceModifier));
+		}
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onFishingExp(PlayerFishEvent event) {
+		// If exp from fishing is disabled, prevent exp from being dropped
+		if (this.disableGrindExp) {
+			event.setExpToDrop(0);
+		}
+		// Otherwise apply general experience modifier
+		else {
+			event.setExpToDrop(applyModifier(event.getExpToDrop(), this.experienceModifier));
+		}
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onBreedExp(EntityBreedEvent event) {
+		// If exp from breeding is disabled, prevent exp from being given
+		if (this.disableGrindExp) {
+			event.setExperience(0);
+		}
+		// Otherwise apply general experience modifier
+		else {
+			event.setExperience(applyModifier(event.getExperience(), this.experienceModifier));
+		}
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onMerchantExp(MerchantRecipe event) {
+		// If exp from merchants is disabled, prevent exp from being rewarded
+		if (this.disableGrindExp) {
 			event.setExperienceReward(false);
 		}
 	}
-	
-	private void createXPBottles(Player player, int totalExp) {
-		ItemMap inv = new ItemMap(player.getInventory());
-		int bottles = inv.getAmount(new ItemStack(Material.GLASS_BOTTLE));
-		int xpavailable = totalExp / xpPerBottle;
-		int remove = Math.min(bottles, xpavailable);
-		
-		if(remove == 0) return;
-		
-		boolean noSpace = false;
-		int bottleCount = 0;
-		ItemMap removeMap = new ItemMap();
-		
-		removeMap.addItemAmount(new ItemStack(Material.GLASS_BOTTLE), remove);
-		
-		for(ItemStack is : removeMap.getItemStackRepresentation()) {
-			int initialAmount = is.getAmount();
-			
-			player.getInventory().removeItem(is);
-			is.setType(Material.EXP_BOTTLE);
-			
-			HashMap<Integer, ItemStack> result = player.getInventory().addItem(is);
-			
-			if(result != null && result.size() > 0) {
-				is.setType(Material.GLASS_BOTTLE);
-				player.getInventory().addItem(is);
-				
-				noSpace = true;
-				
-				break;
-			} else {
-				bottleCount += initialAmount;
-			}
-		}
-		
-		if(bottleCount > 0) {
-			int endXP = totalExp - bottleCount * xpPerBottle;
-			
-			player.setLevel(0);
-			player.setExp(0);
-			player.giveExp(endXP);
-			
-			player.sendMessage(ChatColor.GREEN + "Created " + bottleCount +  " XP bottles.");
-		}
-		
-		if(noSpace) { 
-			player.sendMessage(ChatColor.RED + "Not enough space in inventory for all XP bottles.");
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onExpChange(PlayerExpChangeEvent event) {
+		// If exp orbs are disabled, prevent exp from applying
+		if (this.preventOrbExp) {
+			event.setAmount(0);
 		}
 	}
-	
-	@EventHandler
-	public void onEmeraldXP(PlayerInteractEvent event) {
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onExpBottle(ExpBottleEvent event) {
+		// If xp bottles contain a constant amount of experience, set it
+		if (this.constantBottleExp) {
+			event.setExperience(this.expPerBottle);
+		}
+		// If exp from xp bottles should be applied directly, do so
+		if (this.directBottleExp) {
+			ThrownExpBottle bottle = event.getEntity();
+			ProjectileSource thrower = bottle.getShooter();
+			if (thrower instanceof Player) {
+				Player player = (Player) thrower;
+				player.giveExp(event.getExperience());
+				player.playSound(player.getEyeLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1f, 1f);
+				event.setExperience(0);
+				bottle.teleport(player);
+			}
+		}
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onEmeraldExp(PlayerInteractEvent event) {
 		// If emerald crafting is not enabled, back out
-		if (!emeraldLeveling) {
+		if (!this.emeraldCrafting) {
+			return;
+		}
+		// If emerald leveling is not enabled, back out
+		if (!this.emeraldLeveling) {
 			return;
 		}
 		// If the action is not a right click, back out
@@ -381,8 +410,10 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 				return;
 		}
 		// If the item is not an emerald, back out
-		ItemStack held = event.getPlayer().getInventory().getItemInMainHand();
-		if (held == null || !Material.EMERALD.equals(held.getType()) || held.getDurability() != 0) {
+		Player player = event.getPlayer();
+		PlayerInventory inventory = player.getInventory();
+		ItemStack held = inventory.getItemInMainHand();
+		if (held == null || !held.isSimilar(emerald)) {
 			return;
 		}
 		// If the item is lored, it's probably a custom item, back out
@@ -397,97 +428,248 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 		if (amount <= 0) {
 			return;
 		}
-		// Apply the xp to the player at the cost of an emerald
-		event.getPlayer().giveExp(xpPerBottle * 9);
+		// Determine how much exp should be given
+		int experience = 0;
+		if (this.constantBottleExp) {
+			experience = this.expPerBottle * 9;
+		}
+		else {
+			// Simulate nine thrown bottles, which drop between 3-11 experience
+			// https://minecraft.gamepedia.com/Bottle_o%27_Enchanting
+			for (int i = 0; i < 9; i++) {
+				experience += random.nextInt(11 - 3 + 1) + 3;
+			}
+		}
+		// Apply the exp to the player at the cost of an emerald
+		player.giveExp(experience);
 		if (amount == 1) {
-			event.getPlayer().getInventory().setItemInMainHand(null);
+			inventory.setItemInMainHand(null);
 		}
 		else {
 			held.setAmount(--amount);
-			event.getPlayer().getInventory().setItemInMainHand(held);
+			inventory.setItemInMainHand(held);
 		}
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST)
-	public void xpBottleEvent(ExpBottleEvent event) {
-		if (noExp) {
-			ThrownExpBottle bottle = event.getEntity();
-			ProjectileSource source = bottle.getShooter();
-			if (source instanceof Player) {
-				Player shooter = (Player) source;
-				shooter.giveExp(xpPerBottle);
-				bottle.teleport(shooter);
-			}
-			// NOTE: For some reason event.getHitBlock() and event.getHitEntity() will always return null
-			// and the location of the bottle upon this event's calling can be unexpected, which is why a
-			// radius larger than two is necessary because even if the event calls because the bottle hit
-			// a player, in some circumstances the location of the bottle still may be 1.8 blocks away,
-			// even if the bottle appears to have hit the player's feet or waist. Better to have to sort
-			// through a pool of larger entities than allow blatantly obvious collisions to go undetected
-			else if (source instanceof BlockProjectileSource) {
-				List<Player> nearby = bottle.getNearbyEntities(dispenserXPRadius, dispenserXPRadius + 1, dispenserXPRadius)
-						.stream()
-						.filter((entity) -> entity instanceof Player)
-						.map((entity) -> (Player) entity)
-						.collect(Collectors.toList());
-				// If no player is found, prevent orbs from spawning
-				if (nearby.isEmpty()) {
-					event.setShowEffect(false);
-					event.setExperience(0);
-					return;
-				}
-				Player closest = null;
-				double distance = Double.MAX_VALUE;
-				for (Player player : nearby) {
-					Location playerLocation = player.getLocation();
-					Location bottleLocation = bottle.getLocation();
-					// Reduce the importance of slight y level differences if the bottle is above the player
-					// so that someone standing on higher ground will not take precedence over someone
-					// standing closer, just because the potion is aimed at the latter person's head
-					double diffY = playerLocation.getY() - bottleLocation.getY();
-					if (diffY < 0) {
-						bottleLocation.setY(bottleLocation.getY() + (diffY < -1 ? -1 : diffY));
-					}
-					double tempDistance = playerLocation.distance(bottleLocation);
-					// If there's no other player to compare to, just set this player as the closest
-					// or if this player is closer, then set this player as the closest
-					if (closest == null || tempDistance < distance) {
-						closest = player;
-						distance = tempDistance;
-					}
-				}
-				closest.giveExp(xpPerBottle);
-				bottle.teleport(closest);
-			}
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onPlayerExpRecovery(PlayerInteractEvent event) {
+		// If exp recovery is not enabled, back out
+		if (!this.allowExpRecovery) {
+			return;
 		}
-		else {
-			event.setExperience(xpPerBottle);
+		// If constant bottle xp is not enabled, back out
+		if (!this.constantBottleExp) {
+			return;
+		}
+		// If the action wasn't a block punch, back out
+		if (event.getAction() != Action.LEFT_CLICK_BLOCK) {
+			return;
+		}
+		// If the action somehow doesn't have a block, back out
+		if (!event.hasBlock()) {
+			return;
+		}
+		// If the block being punched isn't an Enchanting Table, back out
+		Block block = event.getClickedBlock();
+		if (block.getType() != Material.ENCHANTMENT_TABLE) {
+			return;
+		}
+		// If the player is not holding glass bottles, back out
+		Player player = event.getPlayer();
+		PlayerInventory inventory = player.getInventory();
+		ItemStack held = inventory.getItemInMainHand();
+		if (held.getType() != Material.GLASS_BOTTLE) {
+			return;
+		}
+		// If the player does not have enough exp, back out
+		int totalExp = computeCurrentXP(player);
+		if (totalExp < this.expPerBottle) {
+			return;
+		}
+		// Attempt to create exp bottles
+		createExpBottles(player, totalExp);
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onPrepareItemEnchant(PrepareItemEnchantEvent event) {
+		CraftInventoryView view = (CraftInventoryView) event.getView();
+		ContainerEnchantTable table = (ContainerEnchantTable) view.getHandle();
+		// If randomise enchants is enabled, randomise the offers
+		if (this.randomiseEnchants) {
+			table.f = random.nextInt();
 		}
 	}
-	
-	@EventHandler(priority = EventPriority.MONITOR)
-	public void xpBottleMonitor(ExpBottleEvent event) {
-		if(event.getExperience() != (noExp ? 0 : xpPerBottle)) {
-			getLogger().log(Level.INFO, "XP control lost: " + event.getExperience());
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onPrepareAnvil(PrepareAnvilEvent event) {
+		// If infinite repair is not enabled, back out
+		if (!this.infiniteRepair) {
+			return;
+		}
+		// If the offer is not valid, back out
+		ItemStack result = event.getResult();
+		if (result == null) {
+			return;
+		}
+		else if (result.getType() == Material.AIR) {
+			return;
+		}
+		else if (result.getAmount() <= 0) {
+			return;
+		}
+		// Attempt to create a CraftItemStack, if it failed, back out
+		net.minecraft.server.v1_12_R1.ItemStack craftItem = CraftItemStack.asNMSCopy(result);
+		if (craftItem == null) {
+			return;
+		}
+		// If the repair cost of the item is less than the maximum repair cost, back out
+		int newRepairCost = this.maxRepairCost - 2;
+		if (craftItem.getRepairCost() < newRepairCost) {
+			return;
+		}
+		// Otherwise set the new repair cost and set the result
+		craftItem.setRepairCost(newRepairCost);
+		event.setResult(CraftItemStack.asBukkitCopy(craftItem));
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onEnchantItem(EnchantItemEvent event) {
+		Player player = event.getEnchanter();
+		// Determine what the player's new level will be after spending their levels
+		int newPlayerLevel = Math.max(0, player.getLevel() - event.getExpLevelCost() - event.whichButton());
+		// Prevent double spending
+		event.setExpLevelCost(0);
+		// Spend the player's levels
+		Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> player.setLevel(newPlayerLevel));
+		// And refill the Lapis Lazuli
+		if (this.fillLapis) {
+			event.getInventory().setItem(1, lapis.clone());
 		}
 	}
-	
-	@EventHandler
-	public void onExpChange(PlayerExpChangeEvent event) {
-		if(noExp) {
-			event.setAmount(0);
+
+	// TODO: This function causes weirdness when you place Lapis Lazuli in the item to enchant slot. It should be
+	//       modified to only cancel the event if items are being added to or removed from the consumable slot.
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onInventoryClick(InventoryClickEvent event) {
+		// If the inventory is creative, back out
+		if (event instanceof InventoryCreativeEvent) {
+			return;
 		}
+		// If fillLapis is not enabled, back out
+		if (!this.fillLapis) {
+			return;
+		}
+		// If the inventory is not that of an Enchanting Table, back out
+		Inventory inventory = event.getClickedInventory();
+		if (inventory == null || inventory.getType() != InventoryType.ENCHANTING) {
+			return;
+		}
+		// If the current item is not Lapis Lazuli, back out
+		ItemStack currentItem = event.getCurrentItem();
+		if (currentItem == null || !currentItem.isSimilar(lapis)) {
+			return;
+		}
+		// Otherwise prevent altering of the Lapis Lazuli
+		event.setCancelled(true);
 	}
-	
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onOpenEnchantingTable(InventoryOpenEvent event) {
+		// If fillLapis is not enabled, back out
+		if (!this.fillLapis) {
+			return;
+		}
+		// If the inventory is not that of an Enchanting Table, back out
+		Inventory inventory = event.getInventory();
+		if (inventory == null || inventory.getType() != InventoryType.ENCHANTING) {
+			return;
+		}
+		// Otherwise fill with Lapis Lazuli
+		event.getInventory().setItem(1, lapis.clone());
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onCloseEnchantingTable(InventoryCloseEvent event) {
+		// If fillLapis is not enabled, back out
+		if (!this.fillLapis) {
+			return;
+		}
+		// If the inventory is not that of an Enchanting Table, back out
+		Inventory inventory = event.getInventory();
+		if (inventory == null || inventory.getType() != InventoryType.ENCHANTING) {
+			return;
+		}
+		// Otherwise emtpy out Lapis Lazuli
+		inventory.setItem(1, null);
+	}
+
+	@EventHandler(priority=EventPriority.HIGHEST)
+	public void onBreakEnchantingTable(BlockBreakEvent event) {
+		// If fillLapis is not enabled, back out
+		if (!this.fillLapis) {
+			return;
+		}
+		// If block is not an Enchanting Table, back out
+		Block block = event.getBlock();
+		if (block.getType() != Material.ENCHANTMENT_TABLE) {
+			return;
+		}
+		// Remove Lapis Lazuli from the drops
+		block.getDrops().removeIf(drop -> drop.isSimilar(lapis));
+	}
+
+	private int applyModifier(int experience, double modifier) {
+		return (int) Math.max(0, Math.ceil(experience * modifier));
+	}
+
 	private int computeCurrentXP(Player player) {
 		float currentLevel = (float) player.getLevel();
 		float progress = player.getExp();
 		float a = 1f, b = 6f, c = 0f, x = 2f, y = 7f;
-		if(currentLevel > 16 && currentLevel <= 31) {
+		if (currentLevel > 16 && currentLevel <= 31) {
 			a = 2.5f; b = -40.5f; c = 360f; x = 5f; y = -38f;
-		} else if(currentLevel >= 32) {
+		}
+		else if(currentLevel >= 32) {
 			a = 4.5f; b = -162.5f; c = 2220f; x = 9f; y = -158f;
 		}
 		return (int) Math.floor(a * currentLevel * currentLevel + b * currentLevel + c + progress * (x * currentLevel + y));
 	}
+
+	private void createExpBottles(Player player, int totalExp) {
+		ItemMap inv = new ItemMap(player.getInventory());
+		int bottles = inv.getAmount(new ItemStack(Material.GLASS_BOTTLE));
+		int xpavailable = totalExp / this.expPerBottle;
+		int remove = Math.min(bottles, xpavailable);
+		if (remove == 0) return;
+		boolean noSpace = false;
+		int bottleCount = 0;
+		ItemMap removeMap = new ItemMap();
+		removeMap.addItemAmount(new ItemStack(Material.GLASS_BOTTLE), remove);
+		for (ItemStack is : removeMap.getItemStackRepresentation()) {
+			int initialAmount = is.getAmount();
+			player.getInventory().removeItem(is);
+			is.setType(Material.EXP_BOTTLE);
+			HashMap<Integer, ItemStack> result = player.getInventory().addItem(is);
+			if (!result.isEmpty()) {
+				is.setType(Material.GLASS_BOTTLE);
+				player.getInventory().addItem(is);
+				noSpace = true;
+				break;
+			}
+			else {
+				bottleCount += initialAmount;
+			}
+		}
+		if (bottleCount > 0) {
+			int endXP = totalExp - bottleCount * this.expPerBottle;
+			player.setLevel(0);
+			player.setExp(0);
+			player.giveExp(endXP);
+			player.sendMessage(ChatColor.GREEN + "Created " + bottleCount +  " XP bottles.");
+		}
+		if (noSpace) {
+			player.sendMessage(ChatColor.RED + "Not enough space in inventory for all XP bottles.");
+		}
+	}
+
 }

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -70,6 +70,7 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	private double xpMod;
 	private double lootMod;
 	private boolean emeraldCrafting;
+	private boolean emeraldLeveling;
 	private Map<EntityType, Double> xpModifiers;
 	private boolean noExp;
 	private double dispenserXPRadius;
@@ -89,6 +90,7 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 		if(emeraldCrafting) {
 			registerRecipes();
 		}
+		emeraldLeveling = getConfig().getBoolean("emerald_leveling", true);
 		xpModifiers = new HashMap<EntityType, Double>();
 		ConfigurationSection entities = getConfig().getConfigurationSection("entities");
 		for(String key : entities.getKeys(false)) {
@@ -347,7 +349,7 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	@EventHandler
 	public void onEmeraldXP(PlayerInteractEvent event) {
 		// If emerald crafting is not enabled, back out
-		if (!emeraldCrafting) {
+		if (!emeraldLeveling) {
 			return;
 		}
 		// If the action is not a right click, back out

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -1,5 +1,6 @@
 package com.civclassic.oldenchanting;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -68,7 +69,7 @@ import vg.civcraft.mc.civmodcore.itemHandling.ItemMap;
 
 public class OldEnchanting extends JavaPlugin implements Listener {
 
-	private static final Random random = new Random();
+	private static final Random random = new SecureRandom();
 
 	private static final ItemStack lapis = new ItemStack(Material.INK_SACK, 64, (short) 4);
 	private static final ItemStack emerald = new ItemStack(Material.EMERALD, 1);

--- a/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
+++ b/src/main/java/com/civclassic/oldenchanting/OldEnchanting.java
@@ -269,7 +269,7 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	}
 
 	@EventHandler
-	public void onFishingXP(EntityBreedEvent event) {
+	public void onBreedXP(EntityBreedEvent event) {
 		if (noExp) {
 			event.setExperience(0);
 		}
@@ -279,7 +279,7 @@ public class OldEnchanting extends JavaPlugin implements Listener {
 	}
 
 	@EventHandler
-	public void onBreedXP(PlayerFishEvent event) {
+	public void onFishingXP(PlayerFishEvent event) {
 		if (noExp) {
 			event.setExpToDrop(0);
 		}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,6 +52,12 @@ exp_per_bottle: 10
 # Allows player's to store their levels in bottles if constant_bottle_exp is enabled
 allow_exp_recovery: true
 
+# Disallows players from creating enchanted books
+disable_enchanted_book_creation: true
+
+# Disallows players from using enchanted books
+disable_enchanted_book_usage: true
+
 # Modifies the exp drops for specific mob types, which will be used in lieu of experience_modifier
 # NOTE: Players have an implicit modifier of 1.0
 # NOTE: Modifiers must be zero or greater

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,7 @@ randomize_enchants: true #randomizes the enchantments every time the item is cli
 xpmod: 0.2 #multiply all xp drops by this
 loot_mult: 1.5 #multiply xp by this for each level of looting
 emerald_crafting: true #enables crafting xp bottles into emeralds
+emerald_leveling: true #endbles gaining xp from right clicking emeralds
 block_natural_exp: true #disables xp from dropping. xp from bottles will be given to players directly
 unnatural_dispensed_xp_radius: 2 #when block_natural_exp is enabled, what should the radius of dispensed xp be?
 infinite_enchant: true #allows infinite enchanting instead of unrepairable items

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,15 +1,59 @@
-hide_enchants: true #hides the enchantment tooltip
-fill_lapis: true #fills second slot with lapis (can't be taken by players)
-randomize_enchants: true #randomizes the enchantments every time the item is clicked
-xpmod: 0.2 #multiply all xp drops by this
-loot_mult: 1.5 #multiply xp by this for each level of looting
-emerald_crafting: true #enables crafting xp bottles into emeralds
-emerald_leveling: true #endbles gaining xp from right clicking emeralds
-block_natural_exp: true #disables xp from dropping. xp from bottles will be given to players directly
-unnatural_dispensed_xp_radius: 2 #when block_natural_exp is enabled, what should the radius of dispensed xp be?
-infinite_enchant: true #allows infinite enchanting instead of unrepairable items
-max_repair_cost: 35 #if infinite_enchant is set to true, then this will define the repair level cost cap
-exp_per_bottle: 10 #the amount of xp each bottle should give and hold
-#give a special xp modifier to certain mobs
+# Hides what enchantment will be granted within the Enchanting Table GUI
+hide_enchants: true
+
+# Automatically fills the consumable slot with the Enchanting Table GUI with Lapis Lazuli
+# NOTE: The Lapis Lazuli cannot be removed by the player
+fill_lapis: true
+
+# Randomises the enchantment offers each time the item is placed in an Enchanting Table
+randomise_enchants: true
+
+# Experience modifier, all experience drops will be multiplied by this
+# NOTE: Does not apply to player exp
+# NOTE: Modifier must be zero or greater
+experience_modifier: 0.2
+
+# Loot modifier, multiply the amount of exp dropped from each level of Looting
+# NOTE: Does not apply to player exp
+# NOTE: Modifier must be zero or greater
+loot_modifier: 1.5
+
+# Enables xp bottles to be crafted from emeralds and vice versa
+emerald_crafting: true
+
+# Enables gaining xp from emeralds directly without needing to craft and use xp bottles if emerald_crafting is enabled
+emerald_leveling: true
+
+# Disables exp from mobs, fishing, mining, breeding, furnace extracting, etc
+disable_grind_exp: true
+
+# Prevents exp orbs from granting xp
+# NOTE: This will not prevent exp orbs from spawning
+prevent_orb_exp: true
+
+# Ensures that the player who threw the xp bottle is the one to get the xp
+# NOTE: experience_modifier will not apply to directly granted exp
+direct_bottle_exp: true
+
+# Allows items to be repaired infinitely, will require a level cap
+infinite_repair: true
+
+# Defines the maximum repair cost of an item if infinite_repair is enabled
+# NOTE: Value must be two or greater
+max_repair_cost: 33
+
+# Ensures that xp bottles produce a set amount of exp
+constant_bottle_exp: true
+
+# Defines the set amount of xp that xp bottles will produce if constant_bottle_exp is enabled
+# NOTE: Value must be a positive integer
+exp_per_bottle: 10
+
+# Allows player's to store their levels in bottles if constant_bottle_exp is enabled
+allow_exp_recovery: true
+
+# Modifies the exp drops for specific mob types, which will be used in lieu of experience_modifier
+# NOTE: Players have an implicit modifier of 1.0
+# NOTE: Modifiers must be zero or greater
 entities:
   ENDER_DRAGON: 0.1

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,6 +7,7 @@ emerald_crafting: true #enables crafting xp bottles into emeralds
 block_natural_exp: true #disables xp from dropping. xp from bottles will be given to players directly
 unnatural_dispensed_xp_radius: 2 #when block_natural_exp is enabled, what should the radius of dispensed xp be?
 infinite_enchant: true #allows infinite enchanting instead of unrepairable items
+max_repair_cost: 35 #if infinite_enchant is set to true, then this will define the repair level cost cap
 exp_per_bottle: 10 #the amount of xp each bottle should give and hold
 #give a special xp modifier to certain mobs
 entities:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ${project.artifactId}
 main: ${project.groupId}.${project.artifactId}
 version: ${project.version}
-author: biggestnerd
+authors: [biggestnerd, Protonull]
 depend: [ProtocolLib]


### PR DESCRIPTION
This is essentially a rewrite of OldEnchanting that achieves all of what the old version did, is backwards compatible, and has new and more specific features.

For example, `block_natural_exp` has been split into three different config options: `disable_grind_exp`, `prevent_orb_exp`, and `direct_bottle_exp`. Though `block_natural_exp` is still supported.

Enchanted Books can now be disabled both in creation and usage.

The plugin is also now `/reload` safe.